### PR TITLE
Format used with stat -c on Linux should be %y, not %Y

### DIFF
--- a/_extensions/now/now.lua
+++ b/_extensions/now/now.lua
@@ -57,7 +57,7 @@ local function last_modified_bsd(file)
 end
 
 local function last_modified_linux(file)
-  local command = "stat -c %Y " .. file  -- Command to get modification time
+  local command = "stat -c %y " .. file  -- Command to get modification time
 
   local result = run_command(command)
   if result == nil then


### PR DESCRIPTION
Couldn't get your extension to detect modification times on my Linux machine, so I checked the man page for `stat`  and, for GNU coreutils 8.30 at least, it suggests that the correct format flag to use with the`-c` option is `%y`,  not `%Y`.

This seems to fix the issue on my Red Hat Enterprise Linux 8 machine. I've not checked other Linux machines.